### PR TITLE
Fix font data reference and link SDL2_ttf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CC = gcc
 TARGET = sinewave_detector
 SRCS = main.c
 CFLAGS = -Wall -O2 `sdl2-config --cflags` -I/usr/include/fftw3
-LDFLAGS = `sdl2-config --libs` -lfftw3 -lm
+LDFLAGS = `sdl2-config --libs` -lSDL2_ttf -lfftw3 -lm
 
 all: $(TARGET)
 

--- a/main.c
+++ b/main.c
@@ -7,7 +7,7 @@
 #include <signal.h>
 
 // Include the separate font header file that you have.
-// We will assume the font data is provided in this header file as 'font_data'.
+// We will assume the font data is provided in this header file.
 #include "font.h"
 
 // --- Configuration Constants ---
@@ -74,8 +74,8 @@ int main(int argc, char* argv[]) {
     }
 
     // --- 3. Font Setup ---
-    // Load the font from the font.h file
-    SDL_RWops* rw = SDL_RWFromConstMem(font_data, sizeof(font_data));
+    // Load the font from the embedded font data in font.h
+    SDL_RWops* rw = SDL_RWFromConstMem(font_ttf, sizeof(font_ttf));
     if (!rw) {
         log_error("Failed to create SDL_RWops from font data");
         cleanup();


### PR DESCRIPTION
## Summary
- Correct font data symbol in `SDL_RWFromConstMem` to match embedded font array
- Link SDL2_ttf library in the build for font rendering support

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_68a2131c08f08326b450b06da0af5f3c