### PR TITLE
Use smaller font size

### DIFF
--- a/main.c
+++ b/main.c
@@ -20,7 +20,7 @@
 #define FREQUENCY_TOLERANCE 5.0 // Tolerance in Hz to avoid flickering output
 #define SINE_WAVE_MIN_HZ 20
 #define SINE_WAVE_MAX_HZ 20000
-#define FONT_SIZE 24
+#define FONT_SIZE 12
 
 // --- Global Variables ---
 static SDL_AudioDeviceID deviceId = 0;


### PR DESCRIPTION
## Summary
- shrink default FONT_SIZE from 24 to 12 so text fits display

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_68a2197f3ab883268d7c1dddc437b95c