### PR TITLE
Refine sine detection with windowing and correct purity metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # sinDet
+
+A simple real-time sine wave detector that uses SDL2 for audio capture and display and FFTW3 for frequency analysis.
+
+## Building
+
+Ensure SDL2, SDL2_ttf, and FFTW3 development libraries are installed, then run:
+
+```
+make
+```
+
+## Usage
+
+Execute the program with `./sinewave_detector`. Use the UP and DOWN arrow keys to adjust how long a tone must be present before it is reported.
+
+Each audio chunk is multiplied by a Hann window before the FFT is performed. Purity is calculated as the ratio of the peak spectral power to the total power, providing more reliable sine wave detection.
+


### PR DESCRIPTION
## Summary
- Apply Hann window to each audio chunk and compute purity from spectral power for more reliable detection
- Display purity as a percentage and document build/run steps

## Testing
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a21b6208348326a200a6df3e4acb80