### PR TITLE
Add basic spectrum visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sinDet
 
-sinDet is a simple real-time sine wave detector. It uses SDL2 for audio capture and display and FFTW3 for frequency analysis to show the strongest sine component in incoming audio.
+sinDet is a simple real-time sine wave detector. It uses SDL2 for audio capture and display and FFTW3 for frequency analysis to show the strongest sine component in incoming audio. A basic spectrum view visualizes the incoming audio so you can see what the application is hearing.
 
 ## Building
 


### PR DESCRIPTION
## Summary
- Show simple frequency spectrum of incoming audio for visual feedback
- Track normalized FFT magnitudes in audio callback
- Document spectrum view in README

## Testing
- `./configure`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a22006eaf483269c48b07923e07a1e