### PR TITLE
Add multi-tone locking to sine detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sinDet
 
-sinDet is a simple real-time sine wave detector. It uses SDL2 for audio capture and display and FFTW3 for frequency analysis to show the strongest sine component in incoming audio. A basic spectrum view visualizes the incoming audio so you can see what the application is hearing.
+sinDet is a real-time sine wave detector. It uses SDL2 for audio capture and display and FFTW3 for frequency analysis to identify and track sine components in incoming audio. The detector can lock onto multiple tones simultaneously, tolerating volume fluctuations much like a phase locked loop. A basic spectrum view visualizes the incoming audio so you can see what the application is hearing.
 
 ## Building
 


### PR DESCRIPTION
## Summary
- Track up to five simultaneous sine waves with new SineTrack structure and helper
- Revamp audio callback to lock onto multiple peaks and maintain detection across volume dips
- Update UI and README to reflect multi-tone phase-lock-style behaviour

## Testing
- `./configure`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a227e01bd88326bfa52b1c8f24ae02