### PR TITLE
Add gain display and band-pass controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,12 @@ make -f Makefile.win
 ## Controls
 
 - **Up/Down Arrow Keys**: Increase or decrease how long a tone must persist before it is reported.
+- **- / =**: Decrease or increase the input gain (supports negative values for attenuation).
+- **Z/X**: Lower or raise the band-pass filter's low cutoff frequency.
+- **C/V**: Lower or raise the band-pass filter's high cutoff frequency.
 - **Esc**: Exit the application.
+
+Current values for persistence, gain, and band-pass range are shown on screen while the app runs.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- Add adjustable gain with support for negative attenuation
- Introduce configurable band-pass filter to limit analyzed frequencies
- Display current persistence, gain and band-pass settings with new key bindings

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68a230433670832692c0dd1c484a2933