### PR TITLE
Add gain display and adjustable band-pass filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ make -f Makefile.win
 
 ## Controls
 
-- **Up/Down Arrow Keys**: Increase or decrease how long a tone must persist before it is reported.
-- **Left/Right Arrow Keys**: Decrease or increase input gain to adjust detection sensitivity.
 - **Esc**: Exit the application.
+- **Up/Down Arrow Keys**: Increase or decrease how long a tone must persist before it is reported.
+- **Left/Right Arrow Keys**: Decrease or increase input gain in 1 dB steps. Negative values attenuate the input.
+- **Z/X Keys**: Decrease or increase the lower cutoff of the band-pass filter.
+- **C/V Keys**: Decrease or increase the upper cutoff of the band-pass filter.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- Display current gain, persistence, and band-pass settings on screen alongside control key reminders.
- Switch gain to dB scale allowing negative values for attenuation and show it continuously.
- Introduce adjustable band-pass filter to ignore fan noise via Z/X and C/V controls.

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a234aa6d1c83268826b42a84bd9d09