### PR TITLE
Fix persistent SDL unrecognized key logs

### DIFF
--- a/main.c
+++ b/main.c
@@ -97,6 +97,9 @@ int main(int argc, char* argv[]) {
         log_error("Failed to initialize SDL");
         return 1;
     }
+    // SDL_Init may reset log settings; reapply the custom filter and priority
+    SDL_LogSetOutputFunction(sdl_log_filter, NULL);
+    SDL_LogSetAllPriority(SDL_LOG_PRIORITY_ERROR);
     // Initialize the SDL_ttf library for text rendering
     if (TTF_Init() == -1) {
         log_error("Failed to initialize SDL_ttf");


### PR DESCRIPTION
## Summary
- Reapply custom SDL log filter after SDL initialization to keep `XF86WakeUp` messages off the console

## Testing
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_68a24146d608832690cdfe598556307f