### PR TITLE
Add optional averaging filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ make -f Makefile.win
 - **Left/Right Arrow Keys**: Decrease or increase input gain in 1 dB steps. Negative values attenuate the input.
 - **Z/X Keys**: Decrease or increase the lower cutoff of the band-pass filter.
 - **C/V Keys**: Decrease or increase the upper cutoff of the band-pass filter.
+- **A Key**: Toggle an averaging filter that smooths the spectrum to reduce noise.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- Smooth the power spectrum with a configurable averaging filter
- Allow toggling the averaging filter with the A key and log changes
- Document the new keyboard shortcut

## Testing
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_68a2439024308326bbf2d5031eb7fbd9