### PR TITLE
Add adjustable squelch and filter SDL key warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ make -f Makefile.win
 - **Z/X Keys**: Decrease or increase the lower cutoff of the band-pass filter.
 - **C/V Keys**: Decrease or increase the upper cutoff of the band-pass filter.
 - **A Key**: Toggle an averaging filter that smooths the spectrum to reduce noise.
+- **S Key**: Toggle squelch. **D/F Keys**: Decrease or increase the squelch threshold.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- Suppress SDL "key not recognized" warnings with a custom log filter
- Add user-configurable squelch with toggle and threshold controls
- Advertise new squelch controls and status in UI and documentation

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a248fd76b0832684a167e57e59f9fe