### PR TITLE
Ensure Linux build dependencies are checked

### DIFF
--- a/configure
+++ b/configure
@@ -20,9 +20,11 @@ check_pkg() {
 }
 
 check_cmd gcc build-essential
+check_cmd make build-essential
 check_cmd sdl2-config libsdl2-dev
 check_cmd pkg-config pkg-config
 
+check_pkg sdl2 libsdl2-dev
 check_pkg SDL2_ttf libsdl2-ttf-dev
 check_pkg fftw3 libfftw3-dev
 


### PR DESCRIPTION
## Summary
- Extend configure script to verify `make` tool is available
- Add pkg-config check for SDL2 library alongside existing SDL2_ttf and FFTW3 checks

## Testing
- `./configure`
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_68a3769634f08326a9e8221e7b7a2bd0